### PR TITLE
Make FrozenClock mutable through setter

### DIFF
--- a/src/FrozenClock.php
+++ b/src/FrozenClock.php
@@ -18,6 +18,11 @@ final class FrozenClock implements Clock
         $this->now = $now;
     }
 
+    public function setTo(DateTimeImmutable $now): void
+    {
+        $this->now = $now;
+    }
+
     public function now(): DateTimeImmutable
     {
         return $this->now;

--- a/test/FrozenClockTest.php
+++ b/test/FrozenClockTest.php
@@ -23,4 +23,23 @@ final class FrozenClockTest extends TestCase
         self::assertSame($now, $clock->now());
         self::assertSame($now, $clock->now());
     }
+
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\Clock\FrozenClock::setTo
+     * @uses   \Lcobucci\Clock\FrozenClock::__construct()
+     * @uses   \Lcobucci\Clock\FrozenClock::now
+     */
+    public function nowSetChangesTheObject()
+    {
+        $oldNow = new DateTimeImmutable();
+        $clock  = new FrozenClock($oldNow);
+
+        $newNow = new DateTimeImmutable();
+        $clock->setTo($newNow);
+
+        self::assertNotSame($oldNow, $clock->now());
+        self::assertSame($newNow, $clock->now());
+    }
 }


### PR DESCRIPTION
Because the FrozenClock is often injected in other objects during
testing, being able to change the current time on the FrozenClock
without reinjecting it in the object under test is quite useful.