### PR TITLE
allow construct FrozenClock without argument

### DIFF
--- a/src/FrozenClock.php
+++ b/src/FrozenClock.php
@@ -9,9 +9,9 @@ final class FrozenClock implements Clock
 {
     private DateTimeImmutable $now;
 
-    public function __construct(DateTimeImmutable $now)
+    public function __construct(DateTimeImmutable $now = null)
     {
-        $this->now = $now;
+        $this->now = $now ?? new DateTimeImmutable();
     }
 
     public function setTo(DateTimeImmutable $now): void

--- a/src/FrozenClock.php
+++ b/src/FrozenClock.php
@@ -9,7 +9,7 @@ final class FrozenClock implements Clock
 {
     private DateTimeImmutable $now;
 
-    public function __construct(DateTimeImmutable $now = null)
+    public function __construct(?DateTimeImmutable $now = null)
     {
         $this->now = $now ?? new DateTimeImmutable();
     }

--- a/test/FrozenClockTest.php
+++ b/test/FrozenClockTest.php
@@ -42,4 +42,21 @@ final class FrozenClockTest extends TestCase
         self::assertNotSame($oldNow, $clock->now());
         self::assertSame($newNow, $clock->now());
     }
+
+	/**
+	 * @test
+	 *
+	 * @covers \Lcobucci\Clock\FrozenClock::__construct
+	 *
+	 * @uses   \Lcobucci\Clock\FrozenClock::now
+	 */
+    public function defaultClockShouldReturnCurrentDateTime(): void
+	{
+		$lower = new DateTimeImmutable();
+		$clock = new FrozenClock();
+		$upper = new DateTimeImmutable();
+
+		self::assertGreaterThanOrEqual($lower, $clock->now());
+		self::assertLessThanOrEqual($upper, $clock->now());
+	}
 }

--- a/test/FrozenClockTest.php
+++ b/test/FrozenClockTest.php
@@ -43,20 +43,20 @@ final class FrozenClockTest extends TestCase
         self::assertSame($newNow, $clock->now());
     }
 
-	/**
-	 * @test
-	 *
-	 * @covers \Lcobucci\Clock\FrozenClock::__construct
-	 *
-	 * @uses   \Lcobucci\Clock\FrozenClock::now
-	 */
+    /**
+     * @test
+     *
+     * @covers \Lcobucci\Clock\FrozenClock::__construct
+     *
+     * @uses   \Lcobucci\Clock\FrozenClock::now
+     */
     public function defaultClockShouldReturnCurrentDateTime(): void
-	{
-		$lower = new DateTimeImmutable();
-		$clock = new FrozenClock();
-		$upper = new DateTimeImmutable();
+    {
+        $lower = new DateTimeImmutable();
+        $clock = new FrozenClock();
+        $upper = new DateTimeImmutable();
 
-		self::assertGreaterThanOrEqual($lower, $clock->now());
-		self::assertLessThanOrEqual($upper, $clock->now());
-	}
+        self::assertGreaterThanOrEqual($lower, $clock->now());
+        self::assertLessThanOrEqual($upper, $clock->now());
+    }
 }


### PR DESCRIPTION
Hi,

I have a real world project where I have implemented basically the same as your package does (except i call Clock ClockInterface, and FronzenClock as ConstantClock instead :)). I have randomly encountered this package and I think that I would replace my code with this package instead of keeping it as part of an unrelated private repository that just wants to use the functionality.

However I have one use case, which is not unsolvable in your implementation, but it would be simpler to allow create frozen clock without arguments, basically to keep the time the same for all consumers thorughout a longer process.