### PR TITLE
fix test of system clock using default timezone

### DIFF
--- a/test/SystemClockTest.php
+++ b/test/SystemClockTest.php
@@ -6,6 +6,7 @@ namespace Lcobucci\Clock;
 use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
+use function date_default_timezone_get;
 
 final class SystemClockTest extends TestCase
 {
@@ -16,7 +17,7 @@ final class SystemClockTest extends TestCase
      */
     public function constructShouldUseSystemDefaultTimezoneIfNoneWasProvided(): void
     {
-        self::assertEquals(new SystemClock(new DateTimeZone('UTC')), new SystemClock());
+        self::assertEquals(new SystemClock(new DateTimeZone(date_default_timezone_get())), new SystemClock());
     }
 
     /**


### PR DESCRIPTION
hi, me again:)

I just noticed that the test for SystemClock is written so that it relies that the machine running the test has UTC as default. Probably would be better to use the actual system default...