### PR TITLE
[WIP] StoppableClock wraps another Clock and can pause and resume at will

### DIFF
--- a/src/StoppableClock.php
+++ b/src/StoppableClock.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Lcobucci\Clock;
+
+use DateTimeImmutable;
+
+class StoppableClock implements Clock
+{
+	private Clock $clock;
+	private ?DateTimeImmutable $pausedAt;
+
+	public function __construct(Clock $clock, ?DateTimeImmutable $pausedAt = null)
+	{
+		$this->clock = $clock;
+		$this->pausedAt = $pausedAt;
+	}
+
+	public function pause(): void
+	{
+		$this->pausedAt = $this->clock->now();
+	}
+
+	public function resume(): void
+	{
+		$this->pausedAt = null;
+	}
+
+	public function isPaused(): bool
+	{
+		return $this->pausedAt !== null;
+	}
+
+	public function now(): DateTimeImmutable
+	{
+		return $this->pausedAt ?? $this->clock->now();
+	}
+}


### PR DESCRIPTION
@lcobucci In consuquence of your thought at #31 

> the client using the API might be interested in both getting the current time and freezing things.

I think that something like this would be a better fit for such a client.

But it is not really a good fit for the use case in #31 as I would have to write:
```
$clock = new StoppableClock(new SystemClock());
$clock->pause();
```
and I woudnt actually use the `resume()` capability.
