### PR TITLE
Allow risky tests

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     colors="true"
     verbose="true"
+    failOnRisky="false"	 
     beStrictAboutOutputDuringTests="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutTodoAnnotatedTests="true"


### PR DESCRIPTION
Infection thinks that risky tests are a failure, unless they're permitted by the configuration.