### PR TITLE
Implement forward compatible Clock-Interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "stella-maris/clock": "^0.1"
+        "stella-maris/clock": "^0.1.4"
     },
     "require-dev": {
         "infection/infection": "^0.26",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.0",
+        "stella-maris/clock": "^0.1"
     },
     "require-dev": {
         "infection/infection": "^0.26",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,56 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6aa2eb0a0ac8287ee0069d7bd7051654",
-    "packages": [],
+    "content-hash": "af17ecc7a44ca3cbe4c0e08e7842b997",
+    "packages": [
+        {
+            "name": "stella-maris/clock",
+            "version": "0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://gitlab.com/stella-maris/clock.git",
+                "reference": "8a0a967896df4c63417385dc69328a0aec84d9cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://gitlab.com/api/v4/projects/stella-maris%2Fclock/repository/archive.zip?sha=8a0a967896df4c63417385dc69328a0aec84d9cf",
+                "reference": "8a0a967896df4c63417385dc69328a0aec84d9cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StellaMaris\\Clock\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andreas Heigl",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
+            "homepage": "https://gitlab.com/stella-maris/clock",
+            "keywords": [
+                "clock",
+                "datetime",
+                "point in time",
+                "psr20"
+            ],
+            "support": {
+                "issues": "https://gitlab.com/stella-maris/clock/-/issues",
+                "source": "https://gitlab.com/stella-maris/clock/-/tree/0.1.4"
+            },
+            "time": "2022-04-17T14:12:26+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "composer/pcre",

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 namespace Lcobucci\Clock;
 
 use DateTimeImmutable;
+use StellaMaris\Clock\ClockInterface;
 
-interface Clock
+interface Clock extends ClockInterface
 {
     public function now(): DateTimeImmutable;
 }


### PR DESCRIPTION
The stella-maris/clock package provides an interface based on the currently proposed status of PSR20. Due to the inactivity of the PSR20 working  group this is a way to already provide interoperability while still maintaining forward compatibility. When the current status of PSR20 will be released at one point in time the stella-maris/clock package will extend the PSR20 interface so that this package becomes immeadiately PSR20 compatible without any further work necessary. In the long run the stella-maris/clock package will then be marked deprecated so that people can then use the PSR20 provided implementation.

Should the implementation of PSR20 change between now and a possible release then this interface will still exist and a possible implementation will need more code-changes anyhow so this interface will still provide some way of interoperability.