### PR TITLE
Replace stella-maris/clock with psr/clock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "~8.1.0 || ~8.2.0",
-        "stella-maris/clock": "^0.1.7"
+        "psr/clock": "^1.0"
     },
     "require-dev": {
         "infection/infection": "^0.26",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7adcca618cd096bcda0eb6e2a5066b6a",
+    "content-hash": "a0baac55041ff891c503dfba30f2551b",
     "packages": [
         {
             "name": "psr/clock",
@@ -53,53 +53,6 @@
                 "source": "https://github.com/php-fig/clock/tree/1.0.0"
             },
             "time": "2022-11-25T14:36:26+00:00"
-        },
-        {
-            "name": "stella-maris/clock",
-            "version": "0.1.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/stella-maris-solutions/clock.git",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/stella-maris-solutions/clock/zipball/fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0|^8.0",
-                "psr/clock": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "StellaMaris\\Clock\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Heigl",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
-            "homepage": "https://gitlab.com/stella-maris/clock",
-            "keywords": [
-                "clock",
-                "datetime",
-                "point in time",
-                "psr20"
-            ],
-            "support": {
-                "source": "https://github.com/stella-maris-solutions/clock/tree/0.1.7"
-            },
-            "time": "2022-11-25T16:15:06+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Clock.php
+++ b/src/Clock.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 namespace Lcobucci\Clock;
 
 use DateTimeImmutable;
-use StellaMaris\Clock\ClockInterface;
+use Psr\Clock\ClockInterface;
 
 interface Clock extends ClockInterface
 {


### PR DESCRIPTION
Hi, I was wondering if this library could replace the stella-maris/clock dependency with the newly accepted phpfig psr-20 interface https://www.php-fig.org/psr/psr-20/ for clock.