### PR TITLE
syntax error

### DIFF
--- a/src/SystemClock.php
+++ b/src/SystemClock.php
@@ -1,18 +1,20 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Lcobucci\Clock;
 
-use DateTimeImmutable;
 use DateTimeZone;
-
+use DateTimeImmutable;
 use function date_default_timezone_get;
 
-/** @immutable */
 final class SystemClock implements Clock
 {
-    public function __construct(private readonly DateTimeZone $timezone)
+    private $timezone;
+
+    public function __construct(DateTimeZone $timezone)
     {
+        $this->timezone = $timezone;
     }
 
     public static function fromUTC(): self


### PR DESCRIPTION
"message": "syntax error, unexpected identifier \"DateTimeZone\", expecting variable",

**resolved**