### PR TITLE
`FrozenClock`: add named constructor to system clock

### DIFF
--- a/src/FrozenClock.php
+++ b/src/FrozenClock.php
@@ -7,6 +7,8 @@ use DateMalformedStringException;
 use DateTimeImmutable;
 use DateTimeZone;
 
+use function date_default_timezone_get;
+
 final class FrozenClock implements Clock
 {
     public function __construct(private DateTimeImmutable $now)
@@ -16,6 +18,11 @@ final class FrozenClock implements Clock
     public static function fromUTC(): self
     {
         return new self(new DateTimeImmutable('now', new DateTimeZone('UTC')));
+    }
+
+    public static function fromSystemTimezone(): self
+    {
+        return new self(new DateTimeImmutable('now', new DateTimeZone(date_default_timezone_get())));
     }
 
     public function setTo(DateTimeImmutable $now): void

--- a/test/FrozenClockTest.php
+++ b/test/FrozenClockTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
+use function date_default_timezone_get;
+
 #[CoversClass(FrozenClock::class)]
 final class FrozenClockTest extends TestCase
 {
@@ -70,5 +72,14 @@ final class FrozenClockTest extends TestCase
         $now   = $clock->now();
 
         self::assertSame('UTC', $now->getTimezone()->getName());
+    }
+
+    #[Test]
+    public function fromSystemTimezoneCreatesAnInstanceUsingTheDefaultTimezoneInSystem(): void
+    {
+        $clock = FrozenClock::fromSystemTimezone();
+        $now   = $clock->now();
+
+        self::assertSame(date_default_timezone_get(), $now->getTimezone()->getName());
     }
 }


### PR DESCRIPTION
Hi, we use `FrozenClock` extensively in our tests, and not having the system timezone available like the `SystemClock` has adds a burden to the test suite that needs to replicate production.